### PR TITLE
instance-id-as-default-param

### DIFF
--- a/src/lib/handler.ts
+++ b/src/lib/handler.ts
@@ -11,12 +11,22 @@ declare var process: {
   };
 };
 
-export const standard_handler = async (incoming_options: {url: string, method: string, data: any, params: string}) => {
+interface IncomingOptions {
+  url: string;
+  method: string;
+  data: any;
+  params: string;
+}
+
+export const standard_handler = async (incoming_options: IncomingOptions) => {
   const default_options = {
     headers: {
       'API-Key': get(store, 'state.logged_in_user.api_key', ''),
     },
     baseURL: get(store, 'state.api_url', COMMON.api.url),
+    params: {
+      instance_id: get(store, 'state.config_module.selected_instance._id', null),
+    },
   };
   const merged = {
     ...default_options,

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -85,17 +85,14 @@ const actions: ActionTree<ConfigState, RootState> = {
     context.commit(USERS_MUTATIONS.SET_PERMISSIONS, sample_permissions);
     return;
 
-    await context.dispatch(CONFIG_ACTIONS.FETCH_LATEST_INSTANCE_CONFIG, {instance_id: instance._id});
-    await context.dispatch(USERS_ACTIONS.FETCH_USERS, {instance_id: instance._id});
-    await context.dispatch(USERS_ACTIONS.FETCH_PERMISSIONS, {instance_id: instance._id});
+    await context.dispatch(CONFIG_ACTIONS.FETCH_LATEST_INSTANCE_CONFIG);
+    await context.dispatch(USERS_ACTIONS.FETCH_USERS);
+    await context.dispatch(USERS_ACTIONS.FETCH_PERMISSIONS);
   },
-  async [CONFIG_ACTIONS.FETCH_LATEST_INSTANCE_CONFIG](context, {instance_id}) {
+  async [CONFIG_ACTIONS.FETCH_LATEST_INSTANCE_CONFIG](context) {
     const options = {
       method: 'get',
       url: '/config/latest',
-      params: {
-        instance_id,
-      },
     } as any;
     try {
       const result: AxiosResponse = await standard_handler(options);
@@ -104,14 +101,11 @@ const actions: ActionTree<ConfigState, RootState> = {
       throw e;
     }
   },
-  async [CONFIG_ACTIONS.UPDATE_INSTANCE_CONFIG](context, {instance_id, instance_config}) {
+  async [CONFIG_ACTIONS.UPDATE_INSTANCE_CONFIG](context, {instance_config}) {
     const options = {
       method: 'put',
       url: '/config/update',
       data: instance_config,
-      params: {
-        instance_id,
-      },
     } as any;
     try {
       const result: AxiosResponse = await standard_handler(options);

--- a/src/store/geodata/index.ts
+++ b/src/store/geodata/index.ts
@@ -27,13 +27,10 @@ export const GEODATA_ACTIONS = {
 };
 
 const actions: ActionTree<GeodataState, RootState> = {
-  async [GEODATA_ACTIONS.FETCH_GEODATA_SUMMARIES](context, {instance_id}) {
+  async [GEODATA_ACTIONS.FETCH_GEODATA_SUMMARIES](context) {
     const options = {
       method: 'get',
       url: '/geodata_summary',
-      params: {
-        instance_id,
-      },
     } as any;
     try {
       const result: AxiosResponse = await standard_handler(options);

--- a/src/store/users/index.ts
+++ b/src/store/users/index.ts
@@ -40,13 +40,10 @@ export const USERS_ACTIONS = {
 };
 
 const actions: ActionTree<UsersState, RootState> = {
-  async [USERS_ACTIONS.FETCH_USERS](context, {instance_id}) {
+  async [USERS_ACTIONS.FETCH_USERS](context) {
     const options = {
       method: 'get',
       url: '/all_users',
-      params: {
-        instance_id,
-      },
     };
     try {
       const result = await standard_handler(options as any);
@@ -69,13 +66,10 @@ const actions: ActionTree<UsersState, RootState> = {
       console.log(e);
     }
   },
-  async [USERS_ACTIONS.FETCH_PERMISSIONS](context, {instance_id}) {
+  async [USERS_ACTIONS.FETCH_PERMISSIONS](context) {
     const options = {
       method: 'get',
       url: '/permission',
-      params: {
-        instance_id,
-      },
     };
     try {
       const result = await standard_handler(options as any);
@@ -84,14 +78,11 @@ const actions: ActionTree<UsersState, RootState> = {
       console.log(e);
     }
   },
-  async [USERS_ACTIONS.UPDATE_PERMISSIONS](context, {permissions, instance_id}) {
+  async [USERS_ACTIONS.UPDATE_PERMISSIONS](context, {permissions}) {
     const options = {
       method: 'put',
       url: '/permissions',
       data: permissions,
-      params: {
-        instance_id,
-      },
     };
     try {
       const result = await standard_handler(options as any);


### PR DESCRIPTION
Suggest moving instance_id into the handler, getting direct from store on every request.