### PR TITLE
get-api-url-from-query

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,7 +1,8 @@
 export default {
   api: {
     version: 'v8',
-    url: 'http://localhost:3000/v8',
+    url: 'https://demo-editor-server.herokuapp.com/v8',
+    query_parameter: 'api-url',
   },
   permissions: {
     dummy_record_value: 'dummy',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,30 @@
+import { Store } from 'vuex';
+import { RootState, ROOT_MUTATIONS } from '@/store';
+import COMMON from '@/lib/common';
+
+const find_get_parameter = (parameterName: string): string | null => {
+  let result = null;
+  let tmp = [];
+
+  location.search
+    .substr(1)
+    .split('&')
+    .forEach((item) => {
+      tmp = item.split('=');
+      if (tmp[0] === parameterName) { result = decodeURIComponent(tmp[1]); }
+    });
+  return result;
+};
+
+export const store_api_url_if_found_as_query_param = (store: Store<RootState>): boolean => {
+  const query_param = COMMON.api.query_parameter;
+  const found = find_get_parameter(query_param);
+
+  if (found) {
+    store.commit(ROOT_MUTATIONS.SET_API_URL, found);
+    console.log('Set API URL from query parameter', found);
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -3,11 +3,6 @@
     <el-alert v-if="error.length" :title="error"></el-alert>
 
     <el-form label-width="120px" @submit="do_login">
-      <el-form-item label="API URL" v-if="ui_edit_api_url">
-        <el-input type="text" v-model="updated_api_url">
-          <el-button slot="append" @click="reset_api_url">Reset</el-button>
-        </el-input>
-      </el-form-item>
 
       <el-form-item label="Username">
         <el-input v-model="username"></el-input>
@@ -17,13 +12,17 @@
         <el-input type="password" v-model="password"></el-input>
       </el-form-item>
 
-      <el-button type="text" @click="ui_edit_api_url = !ui_edit_api_url">
-        <span v-if="!ui_edit_api_url">Edit API URL</span>
-        <span v-if="ui_edit_api_url">Hide API URL</span>
-      </el-button>
+      <el-form-item label="API URL" v-if="ui_edit_api_url" @click="ui_edit_api_url = !ui_edit_api_url">
+        <el-input type="text" v-model="updated_api_url">
+          <el-button slot="append" @click="reset_api_url">Reset</el-button>
+        </el-input>
+      </el-form-item>
 
       <el-form-item>
-        <el-button type="primary" @click="do_login" @keyup.enter="do_login">Login</el-button>
+        <el-button type="primary" @click="do_login" @keyup.enter="do_login" :disabled="username === '' || password === ''">Login</el-button>
+        <el-button type="text" @click="ui_edit_api_url = !ui_edit_api_url" v-if="!ui_edit_api_url">
+          Edit API URL
+        </el-button>
       </el-form-item>
 
     </el-form>

--- a/src/pages/edit/EditJSON/EditJSON.vue
+++ b/src/pages/edit/EditJSON/EditJSON.vue
@@ -31,14 +31,13 @@
   import Vue from 'vue';
   import {validate} from '@disarm/config-validation';
 
-  import EditJSONStructured from './EditJSONStructured.vue';
+  import EditJSONStructured from '@/pages/edit/EditJSON/EditJSONStructured.vue';
   import EditJSONRaw from '@/pages/edit/EditJSON/EditJSONRaw.vue';
+  import {CONFIG_ACTIONS} from '@/store/config';
 
   import {InstanceConfig, ValidationMessage} from '@/types';
   import {TUnifiedResponse} from '@disarm/config-validation/build/module/lib/TUnifiedResponse';
   import {do_prioritise_messages} from '@/lib/priortise_messages';
-
-  import {CONFIG_ACTIONS} from '@/store/config'
 
   export default Vue.extend({
     components: {EditJSONStructured, EditJSONRaw},
@@ -60,7 +59,7 @@
     },
     methods: {
       async update_remote() {
-        await this.$store.dispatch(CONFIG_ACTIONS.UPDATE_INSTANCE_CONFIG, this.live_instance_config)
+        await this.$store.dispatch(CONFIG_ACTIONS.UPDATE_INSTANCE_CONFIG, this.live_instance_config);
       },
       check_if_valid() {
         if (!this.live_instance_config) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,8 +9,8 @@ import Edit from '@/pages/edit/Edit.vue';
 import EditUsers from '@/pages/edit/EditUsers/EditUsers.vue';
 import EditPermissions from '@/pages/edit/EditPermissions/EditPermissions.vue';
 import EditJSON from '@/pages/edit/EditJSON/EditJSON.vue';
-import EditGeodata from '@/pages/edit/EditGeodata/UploadGeodata.vue';
 import GeodataSummary from '@/pages/edit/EditGeodata/GeodataSummary.vue';
+import { store_api_url_if_found_as_query_param } from '@/lib/utils';
 
 Vue.use(Router);
 
@@ -78,6 +78,8 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
+  // Check if api-url is passed as a query param
+  store_api_url_if_found_as_query_param(store);
   // check for logged-in user
   if (!store.state.logged_in_user && (to.name !== 'login')) {
     return next({name: 'login'});

--- a/src/store/users/index.ts
+++ b/src/store/users/index.ts
@@ -82,7 +82,7 @@ const actions: ActionTree<UsersState, RootState> = {
     try {
       const result = await standard_handler(options as any);
       await context.dispatch(USERS_ACTIONS.FETCH_USERS);
-      return result
+      return result;
     } catch (e) {
       throw e;
     }


### PR DESCRIPTION
This improves the basic login experience, allows us to send out the link as something like `https://ds-edit-dev.netlify.com?api-url=https://demo-editor-server.herokuapp.com/v8` and have it already configured for the user without them needing to set the API URL manually.